### PR TITLE
MODSI-8, database design, add match_point table. 

### DIFF
--- a/src/main/java/org/folio/reshare/index/api/SharedIndexService.java
+++ b/src/main/java/org/folio/reshare/index/api/SharedIndexService.java
@@ -44,7 +44,7 @@ public class SharedIndexService implements RouterCreator, TenantInitHooks {
 
 
     return storage(ctx)
-        .upsertBibRecord(localIdentifier, libraryId, matchKey.getKey(), source, inventory)
+        .upsertBibRecord(localIdentifier, libraryId, source, inventory)
         .onSuccess(bibRecord -> ctx.response().setStatusCode(204).end());
   }
 


### PR DESCRIPTION
The PR implements a change to the table structure of the shared index - from having one table, BIB_RECORD, with a fixed number of match value columns, to a normalized, two-table structure, which still has a BIB_RECORD table, but now without any match value columns, and then a MATCH_POINT table to hold those match values instead:

MATCH_POINT
   (BIB_RECORD_ID,
    MATCH_TYPE_ID,
    MATCH_VALUE)

This change is necessary primarily because it allows for an unlimited number of match values of a given type per bib record, for example an unbounded number of ISBNs per bib record, and secondly because it allows for an unbounded number of different match types (defined by match_type_id) with no need to add additional columns to BIB_RECORD for each new match type that we might want to add later.

The change in database structure does not affect the APIs for ingestion or retrieval. It does of course require internal changes to the API implementations, in order to populate and query the table structure.  So in this PR, ingestion is implemented by a trigger on BIB_RECORD that invokes a stored function to update MATCH_POINT in case of inserts or updates to BIB_RECORD (deletion of records in BIB_RECORD are simply cascaded to MATCH_POINT and are thus not part of the stored function). The trigger approach is simple in this case, because the MATCH_POINT table is entirely dependent on the BIB_RECORD table. This implementation will work but it is for proof of concept (that the APIs don't need to change), meaning that, if desired, the ingestion logic could be implemented in Vert.X instead. 

As for batch updates and transactions, this implementation means, that BIB_RECORD can be updated in batch or with longer transactions spanning multiple insert, update or delete operations on BIB_RECORD. The subsequent, "inline" updates to MATCH_POINT would be part of those transactions and be committed and rolled back with them. 

The tables are not meant to be complete and several details, like the use of identifiers for match-types etc, are preliminary. They are merely chosen to be able to use 'inventory' JSON schema that we have at hand from the old SI. 