### PR TITLE
getClusters: Make matchkeyid a required parameter

### DIFF
--- a/server/src/main/java/org/folio/shared/index/api/SharedIndexService.java
+++ b/server/src/main/java/org/folio/shared/index/api/SharedIndexService.java
@@ -106,6 +106,10 @@ public class SharedIndexService implements RouterCreator, TenantInitHooks {
         .mapEmpty();
   }
 
+  void matchKeyNotFound(RoutingContext ctx, String id) {
+    HttpResponse.responseError(ctx, 404, "MatchKey " + id + " not found");
+  }
+
   Future<Void> getClusters(RoutingContext ctx) {
     PgCqlQuery pgCqlQuery = createPgCqlQuery();
     pgCqlQuery.addField(
@@ -119,7 +123,7 @@ public class SharedIndexService implements RouterCreator, TenantInitHooks {
     Storage storage = new Storage(ctx);
     return storage.selectMatchKeyConfig(matchKeyId).compose(conf -> {
       if (conf == null) {
-        HttpResponse.responseError(ctx, 404, "MatchKey " + matchKeyId + " not found");
+        matchKeyNotFound(ctx, matchKeyId);
         return Future.succeededFuture();
       }
       return storage.getClusters(ctx, matchKeyId,
@@ -172,7 +176,7 @@ public class SharedIndexService implements RouterCreator, TenantInitHooks {
     return storage.selectMatchKeyConfig(id)
         .onSuccess(res -> {
           if (res == null) {
-            HttpResponse.responseError(ctx, 404, "MatchKey " + id + " not found");
+            matchKeyNotFound(ctx, id);
             return;
           }
           HttpResponse.responseJson(ctx, 200).end(res.encode());
@@ -190,7 +194,7 @@ public class SharedIndexService implements RouterCreator, TenantInitHooks {
     return storage.updateMatchKeyConfig(id, method, params, update)
         .onSuccess(res -> {
           if (Boolean.FALSE.equals(res)) {
-            HttpResponse.responseError(ctx, 404, "MatchKey " + id + " not found");
+            matchKeyNotFound(ctx, id);
             return;
           }
           ctx.response().setStatusCode(204).end();
@@ -205,7 +209,7 @@ public class SharedIndexService implements RouterCreator, TenantInitHooks {
     return storage.deleteMatchKeyConfig(id)
         .onSuccess(res -> {
           if (Boolean.FALSE.equals(res)) {
-            HttpResponse.responseError(ctx, 404, "MatchKey " + id + " not found");
+            matchKeyNotFound(ctx, id);
             return;
           }
           ctx.response().setStatusCode(204).end();
@@ -235,7 +239,7 @@ public class SharedIndexService implements RouterCreator, TenantInitHooks {
     return storage.initializeMatchKey(id)
         .onSuccess(res -> {
           if (res == null) {
-            HttpResponse.responseError(ctx, 404, "MatchKey " + id + " not found");
+            matchKeyNotFound(ctx, id);
             return;
           }
           HttpResponse.responseJson(ctx, 200).end(res.encode());

--- a/server/src/main/resources/openapi/parameters/matchkeyid.yaml
+++ b/server/src/main/resources/openapi/parameters/matchkeyid.yaml
@@ -1,6 +1,6 @@
 in: query
 name: matchkeyid
-description: Comma separated list of match key config identifiers
-required: false
+description: Match key configuration identifier
+required: true
 schema:
   type: string

--- a/server/src/main/resources/openapi/shared-index-1.0.yaml
+++ b/server/src/main/resources/openapi/shared-index-1.0.yaml
@@ -313,12 +313,10 @@ paths:
       - $ref: headers/okapi-token.yaml
       - $ref: headers/okapi-url.yaml
       - $ref: parameters/limit.yaml
-      - $ref: parameters/matchkeyid.yaml
       - $ref: parameters/query.yaml
       - $ref: parameters/offset.yaml
     get:
-      description: Get records that satisfy CQL query with fields localId,
-        matchkeyId, matchedWith.
+      description: Get records that satisfy CQL query with fields localId, sourceId, globalId.
       operationId: getGlobalRecords
       responses:
         "200":
@@ -398,7 +396,7 @@ paths:
       - $ref: parameters/query.yaml
       - $ref: parameters/offset.yaml
     get:
-      description: Get clusters with matchkeyid
+      description: Get clusters with matchkeyid. CQL query with matchValue, clusterId fields
       operationId: getClusters
       responses:
         "200":
@@ -409,6 +407,8 @@ paths:
                 $ref: schemas/clusters.json
         "400":
           $ref: "#/components/responses/trait_400"
+        "404":
+          $ref: "#/components/responses/trait_404"
         "500":
           $ref: "#/components/responses/trait_500"
   /shared-index/clusters/{clusterId}:

--- a/server/src/test/java/org/folio/shared/index/MainVerticleTest.java
+++ b/server/src/test/java/org/folio/shared/index/MainVerticleTest.java
@@ -651,7 +651,38 @@ public class MainVerticleTest {
   }
 
   @Test
+  public void testMatchKeyIdMissing() {
+    RestAssured.given()
+        .header(XOkapiHeaders.TENANT, tenant1)
+        .header("Content-Type", "application/json")
+        .get("/shared-index/clusters")
+        .then().statusCode(400)
+        .contentType("text/plain")
+        .body(containsString("Missing parameter matchkeyid"));
+  }
+
+  @Test
+  public void testMatchKeyIdNotFound() {
+    String id = UUID.randomUUID().toString();
+    RestAssured.given()
+        .header(XOkapiHeaders.TENANT, tenant1)
+        .param("matchkeyid", id)
+        .header("Content-Type", "application/json")
+        .get("/shared-index/clusters")
+        .then().statusCode(404)
+        .contentType("text/plain")
+        .body(is("MatchKey " + id + " not found"));
+  }
+
+  @Test
   public void testClusters() {
+
+    RestAssured.given()
+        .header(XOkapiHeaders.TENANT, tenant1)
+        .header("Content-Type", "application/json")
+        .get("/shared-index/clusters")
+        .then().statusCode(400);
+
     JsonObject matchKey1 = new JsonObject()
         .put("id", "isbn")
         .put("method", "jsonpath")


### PR DESCRIPTION
And return 404 if it doesn't exist - rather than just getting
an empty response.